### PR TITLE
Unnecessary cloning of arguments

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -10,7 +10,7 @@ module.exports = function() {
         functor;
 
     functor = function() {
-        action.emit(eventLabel, Array.prototype.slice.call(arguments, 0));
+        action.emit(eventLabel, arguments);
     };
 
     /**

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -32,8 +32,7 @@ module.exports = function(definition) {
         };
     };
     Store.prototype.trigger = function() {
-        var args = Array.prototype.slice.call(arguments, 0);
-        store.emit(eventLabel, args);
+        store.emit(eventLabel, arguments);
     };
 
     return new Store();


### PR DESCRIPTION
Afaik, you don't need to clone arguments if you're not using the `Array` utility functions.
