### PR TITLE
Fix unsubscribe test for stores

### DIFF
--- a/test/creatingStores.spec.js
+++ b/test/creatingStores.spec.js
@@ -56,7 +56,7 @@ describe('Creating stores', function() {
                 action(1337, 'ninja');
 
                 setTimeout(function() {
-                  assert.equal(resolved, false);
+                  assert.isFalse(resolved);
                   done();
                 }, 200);
             });


### PR DESCRIPTION
In the unsubscribe test the promise is being rejected
and the error (from assert.fail()) is never caught by
Mocha. For this reason the test is always successful, even when
commenting out the unsubscribe call.
