### PR TITLE
adding Reflux.connect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ exports.listenerMixin = exports.ListenerMixin = require('./listenerMixin');
 
 exports.listenTo = require('./listenTo');
 
+exports.listenToMany = require('./listenToMany');
+
 exports.all = require('./all');
 
 /**

--- a/src/listenToMany.js
+++ b/src/listenToMany.js
@@ -1,0 +1,34 @@
+var Reflux = require('../src');
+
+
+/**
+ * A mixin factory for a React component. Meant as a more convenient way of using the `listenerMixin`,
+ * without having to manually set listeners in the `componentDidMount` method. This version is used
+ * to automatically set up a `listenToMany` call.
+ *
+ * @param {Object} listenables An object of listenables
+ * @returns {Object} An object to be used as a mixin, which sets up the listeners for the given listenables.
+ */
+module.exports = function(listenables){
+    return {
+        /**
+         * Set up the mixin before the initial rendering occurs. Import methods from `listenerMethods`
+         * and then make the call to `listenTo` with the arguments provided to the factory function
+         */
+        componentDidMount: function() {
+            for(var m in Reflux.listenerMethods){
+                if (this[m] !== Reflux.listenerMethods[m]){
+                    if (this[m]){
+                        throw "Can't have other property '"+m+"' when using Reflux.listenToMany!";
+                    }
+                    this[m] = Reflux.listenerMethods[m];
+                }
+            }
+            this.listenToMany(listenables);
+        },
+        /**
+         * Cleans up all listener previously registered. 
+         */
+        componentWillUnmount: Reflux.listenerMethods.stopListeningToAll
+    };
+};

--- a/src/publisherMethods.js
+++ b/src/publisherMethods.js
@@ -9,7 +9,9 @@ module.exports = {
     /**
      * Hook used by the publisher that is invoked before emitting
      * and before `shouldEmit`. The arguments are the ones that the action
-     * is invoked with.
+     * is invoked with. If this function returns something other than
+     * undefined, that will be passed on as arguments for shouldEmit and
+     * emission.
      */
     preEmit: function() {},
 
@@ -43,8 +45,9 @@ module.exports = {
      * Publishes an event using `this.emitter` (if `shouldEmit` agrees)
      */
     trigger: function() {
-        var args = arguments;
-        this.preEmit.apply(this, args);
+        var args = arguments,
+            pre = this.preEmit.apply(this, args);
+        args = pre === undefined ? args : _.isArguments(pre) ? pre : [].concat(pre);
         if (this.shouldEmit.apply(this, args)) {
             this.emitter.emit(this.eventLabel, args);
         }

--- a/test/listenToMany.spec.js
+++ b/test/listenToMany.spec.js
@@ -1,0 +1,51 @@
+var assert = require('chai').assert,
+    sinon = require('sinon'),
+    listenToMany = require('../src/listenToMany'),
+    _ = require('../src/utils'),
+    Reflux = require('../src');
+
+describe('the listenToMany shorthand',function(){
+    describe("when calling the factory",function(){
+        var unsubscriber = sinon.spy(),
+            listenable1 = {listen: sinon.stub().returns(unsubscriber)},
+            listenable2 = {listen: sinon.stub().returns(unsubscriber)},
+            listenables = {
+                firstAction: listenable1,
+                secondAction: listenable2
+            },
+            context = {
+                onFirstAction: sinon.spy(),
+                onSecondAction: sinon.spy()
+            },
+            result = _.extend(context,listenToMany(listenables));
+        it("should return object with componentDidMount and componentWillUnmount methods",function(){
+            assert.isFunction(result.componentDidMount);
+            assert.isFunction(result.componentWillUnmount);
+        });
+        describe("when calling the added componentDidMount",function(){
+            result.componentDidMount();
+            it("should add all methods from listenerMethods",function(){
+                for(var m in Reflux.listenerMethods){
+                    assert.equal(result[m],Reflux.listenerMethods[m]);
+                }
+            });
+            it("should add to a subscriptions array (via listenToMany)",function(){
+                var subs = result.subscriptions;
+                assert.isArray(subs);
+                assert.equal(subs[0].listenable,listenable1);
+                assert.equal(subs[1].listenable,listenable2);
+            });
+            it("should call listen on the listenables correctly (via listenToMany)",function(){
+                assert.equal(listenable1.listen.callCount,1);
+                assert.deepEqual(listenable1.listen.firstCall.args,[context.onFirstAction,result]);
+                assert.equal(listenable2.listen.callCount,1);
+                assert.deepEqual(listenable2.listen.firstCall.args,[context.onSecondAction,result]);
+            });
+        });
+        describe("the componentWillUnmount method",function(){
+            it("should be the same as listenerMethods stopListeningToAll",function(){
+                assert.equal(assert.equal(result.componentWillUnmount,Reflux.listenerMethods.stopListeningToAll));
+            });
+        });
+    });
+});

--- a/test/publisherMethods.spec.js
+++ b/test/publisherMethods.spec.js
@@ -4,76 +4,233 @@ var chai = require('chai'),
     sinon = require('sinon');
 
 describe("the publisher methods",function(){
-	var pub = Reflux.publisherMethods;
-	describe("the listen method",function(){
-		var emitter = {
-				addListener:sinon.spy(),
-				removeListener:sinon.spy()
-			},
-			context = {
-				emitter: emitter,
-				eventLabel: "LABEL",
-			},
-			callback = sinon.spy(),
-			cbcontext = {foo:"BAR"},
-			result = pub.listen.call(context,callback,cbcontext);
-		it("should call addListener correctly",function(){
-			var args = emitter.addListener.firstCall.args;
-			assert.equal(args[0],context.eventLabel);
-			assert.isFunction(args[1]);
-			args[1](["ARG1","ARG2"]);
-			assert.deepEqual(callback.firstCall.args,["ARG1","ARG2"]);
-			assert.equal(callback.firstCall.thisValue,cbcontext);
-		});
-		describe("the returned value",function(){
-			it("should be a function",function(){
-				assert.isFunction(result);
-			});
-			it("should remove the listener correctly",function(){
-				result();
-				assert.deepEqual(emitter.removeListener.firstCall.args,[context.eventLabel,emitter.addListener.firstCall.args[1]]);
-			});
-		});
-	});
-	describe("the trigger method",function(){
-		describe("when shouldEmit returns true",function(){
-			var emitter = {
-					emit: sinon.spy()
-				},
-				context = {
-					eventLabel: "LABEL",
-					preEmit:sinon.spy(),
-					shouldEmit:sinon.stub().returns(true),
-					emitter: emitter
-				};
-			pub.trigger.call(context,"FOO","BAR");
-			it("should call preEmit correctly",function(){
-				assert.deepEqual(context.preEmit.firstCall.args,["FOO","BAR"]);
-			});
-			it("should call shouldEmit correctly",function(){
-				assert.deepEqual(context.shouldEmit.firstCall.args,["FOO","BAR"]);
-			});
-			it("should call emit on the emitter",function(){
-				// args are weird because it is an arguments object
-				var args = emitter.emit.firstCall.args;
-				assert.deepEqual(args[0],"LABEL");
-				assert.deepEqual(args[1][0],"FOO");
-				assert.deepEqual(args[1][1],"BAR");
-			});
-		});
-		describe("when shouldEmit returns false",function(){
-			var emitter = {
-					emit: sinon.spy()
-				},
-				context = {
-					preEmit:sinon.spy(),
-					shouldEmit:sinon.stub().returns(false),
-					emitter: emitter
-				};
-			pub.trigger.call(context,"FOO","BAR");
-			it("should not emit anything",function(){
-				assert.equal(emitter.emit.callCount,0);
-			});
-		});
-	});
+    var pub = Reflux.publisherMethods;
+    describe("the listen method",function(){
+        var emitter = {
+                addListener:sinon.spy(),
+                removeListener:sinon.spy()
+            },
+            context = {
+                emitter: emitter,
+                eventLabel: "LABEL",
+            },
+            callback = sinon.spy(),
+            cbcontext = {foo:"BAR"},
+            result = pub.listen.call(context,callback,cbcontext);
+        it("should call addListener correctly",function(){
+            var args = emitter.addListener.firstCall.args;
+            assert.equal(args[0],context.eventLabel);
+            assert.isFunction(args[1]);
+            args[1](["ARG1","ARG2"]);
+            assert.deepEqual(callback.firstCall.args,["ARG1","ARG2"]);
+            assert.equal(callback.firstCall.thisValue,cbcontext);
+        });
+        describe("the returned value",function(){
+            it("should be a function",function(){
+                assert.isFunction(result);
+            });
+            it("should remove the listener correctly",function(){
+                result();
+                assert.deepEqual(emitter.removeListener.firstCall.args,[context.eventLabel,emitter.addListener.firstCall.args[1]]);
+            });
+        });
+    });
+    describe("the trigger method",function(){
+        describe("when shouldEmit returns true",function(){
+            describe("when preEmit returns undefined",function(){
+                var emitter = {
+                        emit: sinon.spy()
+                    },
+                    context = {
+                        eventLabel: "LABEL",
+                        preEmit:sinon.spy(),
+                        shouldEmit:sinon.stub().returns(true),
+                        emitter: emitter
+                    };
+                pub.trigger.call(context,"FOO","BAR");
+                it("should call preEmit correctly",function(){
+                    assert.deepEqual(context.preEmit.firstCall.args,["FOO","BAR"]);
+                });
+                it("should call shouldEmit correctly",function(){
+                    assert.deepEqual(context.shouldEmit.firstCall.args,["FOO","BAR"]);
+                });
+                it("should call emit on the emitter",function(){
+                    // args are weird because it is an arguments object
+                    var args = emitter.emit.firstCall.args;
+                    assert.deepEqual(args[0],"LABEL");
+                    assert.deepEqual(args[1][0],"FOO");
+                    assert.deepEqual(args[1][1],"BAR");
+                });
+            });
+            describe("when preEmit returns an array of new args",function(){
+                var emitter = {
+                        emit: sinon.spy()
+                    },
+                    oldargs = ["what","ever"],
+                    newargs = ["foo","bar"],
+                    context = {
+                        eventLabel: "LABEL",
+                        preEmit:sinon.stub().returns(newargs),
+                        shouldEmit:sinon.stub().returns(true),
+                        emitter: emitter
+                    };
+                pub.trigger.apply(context,oldargs);
+                it("should call shouldEmit with the changed args",function(){
+                    assert.deepEqual(context.shouldEmit.firstCall.args,newargs);
+                });
+                it("should call emit on the emitter with the changed args",function(){
+                    // args are weird because it is an arguments object
+                    var args = emitter.emit.firstCall.args;
+                    assert.deepEqual(args[0],"LABEL");
+                    assert.deepEqual(args[1],newargs);
+                });
+            });
+            describe("when preEmit returns the arguments array",function(){
+                var emitter = {
+                        emit: sinon.spy()
+                    },
+                    oldargs = ["what","ever"],
+                    context = {
+                        eventLabel: "LABEL",
+                        preEmit:function(){return arguments;},
+                        shouldEmit:sinon.stub().returns(true),
+                        emitter: emitter
+                    };
+                pub.trigger.apply(context,oldargs);
+                it("should correctly call shouldEmit as if we returned an array",function(){
+                    assert.deepEqual(oldargs,context.shouldEmit.firstCall.args);
+                });
+                it("should call emit the same way too",function(){
+                    var args = emitter.emit.firstCall.args;
+                    assert.deepEqual(args[0],"LABEL");
+                    assert.deepEqual(args[1][0],oldargs[0]);
+                    assert.deepEqual(args[1][1],oldargs[1]);
+                });
+            });
+            describe("when preEmit returns a string",function(){
+                var emitter = {
+                        emit: sinon.spy()
+                    },
+                    oldargs = ["what","ever"],
+                    newarg = "I SHOULD BE USED AS A SINGLE ARG",
+                    context = {
+                        eventLabel: "LABEL",
+                        preEmit:sinon.stub().returns(newarg),
+                        shouldEmit:sinon.stub().returns(true),
+                        emitter: emitter
+                    };
+                pub.trigger.apply(context,oldargs);
+                it("should call shouldEmit with the string",function(){
+                    assert.deepEqual([newarg],context.shouldEmit.firstCall.args);
+                });
+                it("should call emit with the string too",function(){
+                    var args = emitter.emit.firstCall.args;
+                    assert.deepEqual(args[0],"LABEL");
+                    assert.deepEqual(args[1],[newarg]);
+                });
+            });
+            describe("when preEmit returns a number",function(){
+                var emitter = {
+                        emit: sinon.spy()
+                    },
+                    oldargs = ["what","ever"],
+                    newarg = 12345,
+                    context = {
+                        eventLabel: "LABEL",
+                        preEmit:sinon.stub().returns(newarg),
+                        shouldEmit:sinon.stub().returns(true),
+                        emitter: emitter
+                    };
+                pub.trigger.apply(context,oldargs);
+                it("should call shouldEmit with the number",function(){
+                    assert.deepEqual([newarg],context.shouldEmit.firstCall.args);
+                });
+                it("should call emit with the number too",function(){
+                    var args = emitter.emit.firstCall.args;
+                    assert.deepEqual(args[0],"LABEL");
+                    assert.deepEqual(args[1],[newarg]);
+                });
+            });
+			describe("when preEmit returns false",function(){
+                var emitter = {
+                        emit: sinon.spy()
+                    },
+                    oldargs = ["what","ever"],
+                    newarg = false,
+                    context = {
+                        eventLabel: "LABEL",
+                        preEmit:sinon.stub().returns(newarg),
+                        shouldEmit:sinon.stub().returns(true),
+                        emitter: emitter
+                    };
+                pub.trigger.apply(context,oldargs);
+                it("should call shouldEmit with false",function(){
+                    assert.deepEqual([newarg],context.shouldEmit.firstCall.args);
+                });
+                it("should call emit with false too",function(){
+                    var args = emitter.emit.firstCall.args;
+                    assert.deepEqual(args[0],"LABEL");
+                    assert.deepEqual(args[1],[newarg]);
+                });
+            });
+            describe("when preEmit returns an object",function(){
+                var emitter = {
+                        emit: sinon.spy()
+                    },
+                    oldargs = ["what","ever"],
+                    newarg = {a:"foo",b:"bar"},
+                    context = {
+                        eventLabel: "LABEL",
+                        preEmit:sinon.stub().returns(newarg),
+                        shouldEmit:sinon.stub().returns(true),
+                        emitter: emitter
+                    };
+                pub.trigger.apply(context,oldargs);
+                it("should call shouldEmit with the object",function(){
+                    assert.deepEqual([newarg],context.shouldEmit.firstCall.args);
+                });
+                it("should call emit with the object too",function(){
+                    var args = emitter.emit.firstCall.args;
+                    assert.deepEqual(args[0],"LABEL");
+                    assert.deepEqual(args[1],[newarg]);
+                });
+            });
+			describe("when preEmit returns a function",function(){
+                var emitter = {
+                        emit: sinon.spy()
+                    },
+                    oldargs = ["what","ever"],
+                    newarg = function(foo,bar){console.log(foo,bar);},
+                    context = {
+                        eventLabel: "LABEL",
+                        preEmit:sinon.stub().returns(newarg),
+                        shouldEmit:sinon.stub().returns(true),
+                        emitter: emitter
+                    };
+                pub.trigger.apply(context,oldargs);
+                it("should call shouldEmit with the function",function(){
+                    assert.deepEqual([newarg],context.shouldEmit.firstCall.args);
+                });
+                it("should call emit with the function too",function(){
+                    var args = emitter.emit.firstCall.args;
+                    assert.deepEqual(args[0],"LABEL");
+                    assert.deepEqual(args[1],[newarg]);
+                });
+            });
+        });
+        describe("when shouldEmit returns false",function(){
+            var emitter = {
+                    emit: sinon.spy()
+                },
+                context = {
+                    preEmit:sinon.spy(),
+                    shouldEmit:sinon.stub().returns(false),
+                    emitter: emitter
+                };
+            pub.trigger.call(context,"FOO","BAR");
+            it("should not emit anything",function(){
+                assert.equal(emitter.emit.callCount,0);
+            });
+        });
+    });
 });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -8,4 +8,13 @@ describe("the utils object",function(){
     		assert.equal(_.callbackName("anAction"),"onAnAction");
     	});
     });
+    describe("the isArguments method",function(){
+    	it("should correctly identify the arguments object",function(){
+    		assert.equal(true,_.isArguments(arguments));
+    	});
+    	it("should return false for anything that isn't the arguments object",function(){
+    		assert.equal(false,_.isArguments([1,2,3]));
+    		assert.equal(false,_.isArguments({length:0}));
+    	});
+    });
 });


### PR DESCRIPTION
After several iterations, I think I've arrived at a good convenience method for the common use case when you want to make a React component set its state to whatever a listenable returns.

This pull request exposes `Reflux.connect(listenable,[stateKey])`, intented to be used as a mixin much like `Reflux.listenTo`. If `stateKey` is supplied then it will do `setState({<stateKey>:data})`, otherwise just `setState(data)`.

Here's the `Reflux.listenTo` example from the README:

``` javascript
var Status = React.createClass({
    mixins: [Reflux.listenTo(statusStore,"onStatusChange")],
    onStatusChange: function(status) {
        this.setState({
            currentStatus: status
        });
    },
    render: function() {
        // render specifics
    }
});
```

...which using `Reflux.connect` instead can be reduced to this:

``` javascript
var Status = React.createClass({
    mixins: [Reflux.connect(statusStore,"currentStatus")],
    render: function() {
        // render specifics
    }
});
```

Isn't it beatiful? Absolutely nothing boilerplaty whatsoever! :)

I found in my `Reflux` app I could almost always use `Reflux.connect` as it was only in very rare cases that I needed to do some special logic.
