### PR TITLE
adding sync option to action creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ statusUpdate(data); // Invokes the action statusUpdate
 statusUpdate.triggerAsync(data); // same effect as above
 ```
 
-If `options.sync` is true, the functor will instead be bound to `action.trigger` which is a synchronous operation.
+If `options.sync` is true, the functor will instead call `action.trigger` which is a synchronous operation. You can change `action.sync` during the lifetime of the action, and the following calls will honour that change.
 
 There is also a convenience function for creating multiple actions.
 

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -23,7 +23,7 @@ module.exports = function(definition) {
     });
 
     var functor = function() {
-        functor[definition.sync?"trigger":"triggerAsync"].apply(functor, arguments);
+        functor[functor.sync?"trigger":"triggerAsync"].apply(functor, arguments);
     };
 
     _.extend(functor,context);

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -48,6 +48,28 @@ describe('Creating action', function() {
             syncaction();
             assert.equal(true,synccalled);
         });
+        describe("when changed during lifetime",function(){
+            var syncaction = Reflux.createAction({sync:true}),
+            asyncaction = Reflux.createAction(),
+            synccalled = false,
+            asynccalled = false,
+            store = Reflux.createStore({
+                sync: function(){synccalled=true;},
+                async: function(){asynccalled=true;}
+            });
+            store.listenTo(syncaction,"sync");
+            store.listenTo(asyncaction,"async");
+            it("should be asynchronous if initial sync was overridden",function(){
+                syncaction.sync = false;
+                syncaction();
+                assert.equal(false,synccalled);
+            });
+            it("should be synchronous if set during lifetime",function(){
+                asyncaction.sync = true;
+                asyncaction();
+                assert.equal(true,asynccalled);
+            });
+        });
     });
 
     describe('when listening to action', function() {


### PR DESCRIPTION
This PR adds a `sync` option to `createAction`, which will make the action functor invoke `trigger` instead of `triggerAsync`.
