### PR TITLE
ReplaceState not SetState, resolves #113.

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -12,7 +12,7 @@ module.exports = function(listenable,key){
                     this[m] = Reflux.ListenerMethods[m];
                 }
             }
-            var me = this, cb = (key === undefined ? this.setState : function(v){me.setState(_.object([key],[v]));});
+            var me = this, cb = (key === undefined ? this.replaceState : function(v){me.setState(_.object([key],[v]));});
             this.listenTo(listenable,cb,cb);
         },
         componentWillUnmount: Reflux.ListenerMixin.componentWillUnmount


### PR DESCRIPTION
As per #113, `Reflux.connect(MyStore)` will destroy the state object's prototype. Yikes. Switch to using replaceState instead of setState to not do this.
