### PR TITLE
removed warning on mixin combo

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -13,19 +13,7 @@ module.exports = function(listenable,key){
             }
         },
         componentDidMount: function(){
-            var warned = false;
-            for(var m in Reflux.ListenerMethods){
-                if (this[m] && typeof console && typeof console.warn === "function" && !warned ){
-                    console.warn(
-                        "Component using Reflux.connect already had property '"+m+"'. "+
-                        "Either you had your own property with that name which was now overridden, "+
-                        "or you combined connect with ListenerMixin which is unnecessary as connect "+
-                        "will include the ListenerMixin methods automatically."
-                    );
-                    warned = true;
-                }
-                this[m] = Reflux.ListenerMethods[m];
-            }
+            _.extend(this,Reflux.ListenerMethods);
             var me = this, cb = (key === undefined ? this.setState : function(v){me.setState(_.object([key],[v]));});
             this.listenTo(listenable,cb);
         },

--- a/test/usingConnectMixin.spec.js
+++ b/test/usingConnectMixin.spec.js
@@ -96,15 +96,4 @@ describe('using the connect(...) mixin',function(){
             assert.deepEqual([_.object([key],[triggerdata])],context.setState.firstCall.args);
         });
     });
-    describe("together with ListenerMixin in a React component",function(){
-        var store = Reflux.createStore({}),
-            def = {setState:function(){}},
-            fakecomponent = _.extend(def,Reflux.connect(store),Reflux.ListenerMethods);
-        it("should log a warning)",function(){
-            sinon.spy(console,"warn");
-            fakecomponent.componentDidMount();
-            assert(console.warn.calledOnce);
-            console.warn.restore();
-        });
-    });
 });


### PR DESCRIPTION
As pointed out in #142, warnings are shown for multiple connect calls which is incorrect. This PR removes the warning loop altogether, as it wasn't really needed in the first place.
