### PR TITLE
Support multiple usages of Reflux.connect on the same react components.

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -1,34 +1,34 @@
 var Reflux = require('../src'),
     _ = require('./utils');
 
+function prepareStateForKey (state, key) {
+	if (key === undefined) {
+		return state;
+	}
+
+	return _.object([key],[state]);
+}
+
 module.exports = function(listenable,key){
-    return {
-        getInitialState: function(){
-            if (!_.isFunction(listenable.getInitialState)) {
-                return {};
-            } else if (key === undefined) {
-                return listenable.getInitialState();
-            } else {
-                return _.object([key],[listenable.getInitialState()]);
-            }
-        },
-        componentDidMount: function(){
-            var warned = false;
-            for(var m in Reflux.ListenerMethods){
-                if (this[m] && typeof console && typeof console.warn === "function" && !warned ){
-                    console.warn(
-                        "Component using Reflux.connect already had property '"+m+"'. "+
-                        "Either you had your own property with that name which was now overridden, "+
-                        "or you combined connect with ListenerMixin which is unnecessary as connect "+
-                        "will include the ListenerMixin methods automatically."
-                    );
-                    warned = true;
-                }
-                this[m] = Reflux.ListenerMethods[m];
-            }
-            var me = this, cb = (key === undefined ? this.setState : function(v){me.setState(_.object([key],[v]));});
-            this.listenTo(listenable,cb);
-        },
-        componentWillUnmount: Reflux.ListenerMixin.componentWillUnmount
-    };
+	return {
+		getInitialState: function (){
+			if (_.isFunction(listenable.getInitialState)) {
+				return prepareStateForKey(listenable.getInitialState(), key) || {};
+			} else {
+				return {};
+			}
+		},
+
+		componentWillMount: function (){
+			this.unbindListener = listenable.listen(function (state) {
+				this.setState(
+					prepareStateForKey(state, key)
+				);
+			}.bind(this));
+		},
+
+		componentWillUnmount: function() {
+			this.unbindListener();
+		}
+	};
 };


### PR DESCRIPTION
Recent changes in Reflux.connect makes this impossible.

**Example use case:**

``` Javascript
var Layout = React.createClass({
    mixins: [
        Reflux.connect(MenuStore, "menu"),
        Reflux.connect(FriendStore, "friends"),
        Reflux.connect(RouteStore, "route"),
    ],
    render: function () {
        return (
            <div id="layout">
                <Menu items={this.state.menu.items}/>
                <Friends items={this.state.friends}/>
                <Content items={this.state.route.view}/>
            </div>
        );
    }
});
```
