### PR TITLE
Extend Reflux.createActions to accept a mixed array of strings and definition objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,13 +45,19 @@ exports.Promise = _.Promise;
  */
 exports.createActions = function(definitions) {
     var actions = {};
-    for (var k in definitions){
-        if (definitions.hasOwnProperty(k)) {
-            var val = definitions[k],
-                actionName = _.isObject(val) ? k : val;
+    if (definitions instanceof Array) {
+        definitions.forEach(function(val) {
+            var isObj = _.isObject(val),
+                actionName = isObj ? Object.keys(val)[0] : val;
 
+            val = isObj ? val[actionName] : val;
             actions[actionName] = exports.createAction(val);
-        }
+        });
+    } else {
+        Object.keys(definitions).forEach(function(actionName) {
+            var val = definitions[actionName];
+            actions[actionName] = exports.createAction(val);
+        });
     }
     return actions;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -43,24 +43,30 @@ exports.Promise = _.Promise;
  * @param definitions the definitions for the actions to be created
  * @returns an object with actions of corresponding action names
  */
-exports.createActions = function(definitions) {
-    var actions = {};
-    if (definitions instanceof Array) {
-        definitions.forEach(function(val) {
-            var isObj = _.isObject(val),
-                actionName = isObj ? Object.keys(val)[0] : val;
-
-            val = isObj ? val[actionName] : val;
-            actions[actionName] = exports.createAction(val);
-        });
-    } else {
+exports.createActions = (function() {
+    var reducer = function(definitions, actions) {
         Object.keys(definitions).forEach(function(actionName) {
             var val = definitions[actionName];
             actions[actionName] = exports.createAction(val);
         });
-    }
-    return actions;
-};
+    };
+
+    return function(definitions) {
+        var actions = {};
+        if (definitions instanceof Array) {
+            definitions.forEach(function(val) {
+                if (_.isObject(val)) {
+                    reducer(val, actions);
+                } else {
+                    actions[val] = exports.createAction(val);
+                }
+            });
+        } else {
+            reducer(definitions, actions);
+        }
+        return actions;
+    };
+})();
 
 /**
  * Sets the eventmitter that Reflux uses

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -329,7 +329,14 @@ describe('Creating multiple actions from an mixed array of strings and object de
     var actionNames, actions;
 
     beforeEach(function () {
-        actionNames = ['foo', 'bar', { baz: { asyncResult: true, children: ['woo'] }}];
+        actionNames = [
+            'foo',
+            'bar',
+            { baz: { asyncResult: true, children: ['woo'] }},
+            {
+                anotherFoo: { asyncResult: true },
+                anotherBar: { children: ['wee'] }
+            }];
         actions = Reflux.createActions(actionNames);
     });
 
@@ -337,6 +344,8 @@ describe('Creating multiple actions from an mixed array of strings and object de
         assert.property(actions, 'foo');
         assert.property(actions, 'bar');
         assert.property(actions, 'baz');
+        assert.property(actions, 'anotherFoo');
+        assert.property(actions, 'anotherBar');
     });
 
     it('should contain action functor on foo, bar and baz properties with children', function() {
@@ -346,6 +355,9 @@ describe('Creating multiple actions from an mixed array of strings and object de
         assert.isFunction(actions.baz.completed);
         assert.isFunction(actions.baz.failed);
         assert.isFunction(actions.baz.woo);
+        assert.isFunction(actions.anotherFoo.completed);
+        assert.isFunction(actions.anotherFoo.failed);
+        assert.isFunction(actions.anotherBar.wee);
     });
 
     describe('when listening to any of the actions created this way', function() {


### PR DESCRIPTION
I want to be able to create async and non-async actions in one go, like this:

``var actions = Reflux.createActions(['foo', 'bar', { baz: { asyncResult: true } }]);``

instead of having to do something ugly like this:

``var actions = Reflux.createActions({ foo: {}, bar: {}, baz: { asyncResult: true }});``

Regarding the tests, I think they could be merged with the existing createActions([]) tests, but for now I simply copy&pasted and adjusted them. Let me know and I'll gladly merge them.

Let me know what you think, thanks!