### PR TITLE
Drop React Peer Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,5 @@
     "mocha": "latest",
     "q": "^1.0.1",
     "sinon": "^1.10.3"
-  },
-  "peerDependencies": {
-    "react": ">=0.12.2 <0.14.0"
   }
 }


### PR DESCRIPTION
PeerDeps are deprecated by NPM3
And React 0.14 just dropped, so this is a blocker to use React 0.14 without updating NPM.

Reflux should make it comply with current standards.