### PR TITLE
Add dist to npm repo

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 node_modules/
 test/
 tmp/
-dist/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflux",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A simple library for uni-directional dataflow application architecture inspired by ReactJS Flux",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Addresses: https://github.com/reflux/refluxjs/issues/441

I also just ran into this issue. Are any big reasons to not include the dist in the npm repo? The current setup forces you to use bower, which is not ideal. A quick explanation or a merge + publish would be much appreciated. Thanks!