### PR TITLE
Deprecate keyless connect() and connectFilter()

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ There is also `Reflux.listenToMany` which works in exactly the same way, exposin
 
 #### Using Reflux.connect
 
-If all you want to do is update the state of your component to whatever the data store transmits, you can use `Reflux.connect(listener,[stateKey])` as a mixin. If you supply a `stateKey` the state will be updated through `this.setState({<stateKey>:data})`, otherwise `this.setState(data)`. Here's the example above changed to use this syntax:
+If all you want to do is update the state of your component to whatever the data store transmits, you can use `Reflux.connect(listener,stateKey)` as a mixin. The state is updated via `this.setState({<stateKey>:data})`. Here's the example above changed to use this syntax:
 
 ```javascript
 var Status = React.createClass({

--- a/src/connect.js
+++ b/src/connect.js
@@ -2,26 +2,26 @@ var ListenerMethods = require('reflux-core/lib/ListenerMethods'),
     ListenerMixin = require('./ListenerMixin'),
     _ = require('reflux-core/lib/utils');
 
-module.exports = function(listenable,key) {
+module.exports = function(listenable, key) {
+
+    _.throwIf(typeof(key) === 'undefined', 'Reflux.connect() requires a key.');
+
     return {
         getInitialState: function() {
             if (!_.isFunction(listenable.getInitialState)) {
                 return {};
-            } else if (key === undefined) {
-                return listenable.getInitialState();
-            } else {
-                return _.object([key],[listenable.getInitialState()]);
             }
+
+            return _.object([key],[listenable.getInitialState()]);
         },
         componentDidMount: function() {
-            var me = this,
-                cb = (key === undefined ? me.setState : function(v) {
-                    me.setState(_.object([key],[v]));
-                });
+            var me = this;
 
             _.extend(me, ListenerMethods);
 
-            this.listenTo(listenable, cb);
+            this.listenTo(listenable, function(v) {
+                me.setState(_.object([key],[v]));
+            });
         },
         componentWillUnmount: ListenerMixin.componentWillUnmount
     };

--- a/src/connectFilter.js
+++ b/src/connectFilter.js
@@ -3,38 +3,33 @@ var ListenerMethods = require('reflux-core/lib/ListenerMethods'),
     _ = require('reflux-core/lib/utils');
 
 module.exports = function(listenable, key, filterFunc) {
-    filterFunc = _.isFunction(key) ? key : filterFunc;
+
+    _.throwIf(_.isFunction(key), 'Reflux.connectFilter() requires a key.');
+
     return {
         getInitialState: function() {
             if (!_.isFunction(listenable.getInitialState)) {
                 return {};
-            } else if (_.isFunction(key)) {
-                return filterFunc.call(this, listenable.getInitialState());
+            }
+
+            // Filter initial payload from store.
+            var result = filterFunc.call(this, listenable.getInitialState());
+            if (typeof(result) !== 'undefined') {
+                return _.object([key], [result]);
             } else {
-                // Filter initial payload from store.
-                var result = filterFunc.call(this, listenable.getInitialState());
-                if (typeof(result) !== "undefined") {
-                    return _.object([key], [result]);
-                } else {
-                    return {};
-                }
+                return {};
             }
         },
         componentDidMount: function() {
-            _.extend(this, ListenerMethods);
             var me = this;
-            var cb = function(value) {
-                if (_.isFunction(key)) {
-                    me.setState(filterFunc.call(me, value));
-                } else {
-                    var result = filterFunc.call(me, value);
-                    me.setState(_.object([key], [result]));
-                }
-            };
 
-            this.listenTo(listenable, cb);
+            _.extend(this, ListenerMethods);
+
+            this.listenTo(listenable, function(value) {
+                var result = filterFunc.call(me, value);
+                me.setState(_.object([key], [result]));
+            });
         },
         componentWillUnmount: ListenerMixin.componentWillUnmount
     };
 };
-

--- a/test/usingConnectFilterMixin.spec.js
+++ b/test/usingConnectFilterMixin.spec.js
@@ -17,7 +17,7 @@ describe('using the connectFilter(...) mixin',function(){
                 listen: sinon.spy()
             },
             context = {setState: sinon.spy()};
-        _.extend(context,connectFilter(listenable, dummyFilter));
+        _.extend(context,connectFilter(listenable, "KEY", dummyFilter));
 
         it("should pass empty object to state",function(){
             assert.deepEqual({},context.getInitialState());
@@ -72,35 +72,17 @@ describe('using the connectFilter(...) mixin',function(){
     });
 
     describe("when calling without key",function(){
-        var initialstate = "DEFAULTDATA",
-            listenable = {
-                listen: sinon.spy(),
-                getInitialState: sinon.stub().returns(initialstate)
-            },
-            context = {setState: sinon.spy()},
-            result = _.extend(context,connectFilter(listenable, dummyFilter));
 
-        it("should add getInitialState and componentDidMount and WillUnmount",function(){
-            assert.isFunction(context.getInitialState);
-            assert.isFunction(context.componentDidMount);
-            assert.isFunction(context.componentWillUnmount);
-            assert.equal(context.componentWillUnmount,Reflux.ListenerMethods.stopListeningToAll);
-        });
+        it("should throw.",function(){
 
-        it("should pass initial state to state",function(){
-            assert.deepEqual(initialstate.slice(0,2),context.getInitialState());
-        });
+            var listenable = {
+                listen: function() {},
+                getInitialState: function() {}
+            };
 
-        result.componentDidMount();
-
-        it("should call listen on the listenable correctly",function(){
-            assert.equal(1,listenable.listen.callCount);
-            assert.isFunction(listenable.listen.firstCall.args[0]);
-            assert.equal(context,listenable.listen.firstCall.args[1]);
-        });
-
-        it("should store the subscription object correctly",function(){
-            assert.equal(listenable,context.subscriptions[0].listenable);
+            assert.throws(function () {
+                connectFilter(listenable, dummyFilter);
+            }, 'Reflux.connectFilter() requires a key.');
         });
 
     });
@@ -146,4 +128,3 @@ describe('using the connectFilter(...) mixin',function(){
         });
     });
 });
-

--- a/test/usingConnectMixin.spec.js
+++ b/test/usingConnectMixin.spec.js
@@ -15,7 +15,7 @@ describe('using the connect(...) mixin',function(){
                 listen: sinon.spy()
             },
             context = {setState: sinon.spy()};
-        _.extend(context,connect(listenable));
+        _.extend(context,connect(listenable, "KEY"));
 
         it("should pass empty object to state",function(){
             assert.deepEqual({},context.getInitialState());
@@ -23,35 +23,17 @@ describe('using the connect(...) mixin',function(){
     });
 
     describe("when calling without key",function(){
-        var initialstate = "DEFAULTDATA",
-            listenable = {
-                listen: sinon.spy(),
-                getInitialState: sinon.stub().returns(initialstate)
-            },
-            context = {setState: sinon.spy()},
-            result = _.extend(context,connect(listenable));
 
-        it("should add getInitialState and componentDidMount and WillUnmount",function(){
-            assert.isFunction(context.getInitialState);
-            assert.isFunction(context.componentDidMount);
-            assert.isFunction(context.componentWillUnmount);
-            assert.equal(context.componentWillUnmount,Reflux.ListenerMethods.stopListeningToAll);
-        });
+        it("should throw.",function(){
 
-        it("should pass initial state to state",function(){
-            assert.deepEqual(initialstate,context.getInitialState());
-        });
+            var listenable = {
+                listen: function() {},
+                getInitialState: function() {}
+            };
 
-        result.componentDidMount();
-
-        it("should call listen on the listenable correctly",function(){
-            assert.equal(1,listenable.listen.callCount);
-            assert.equal(context.setState,listenable.listen.firstCall.args[0]);
-            assert.equal(context,listenable.listen.firstCall.args[1]);
-        });
-
-        it("should store the subscription object correctly",function(){
-            assert.equal(listenable,context.subscriptions[0].listenable);
+            assert.throws(function () {
+                connect(listenable);
+            }, 'Reflux.connect() requires a key.');
         });
 
     });


### PR DESCRIPTION
This is meant to resolve #340.  Figured we should get it in while making changes for 0.4.0.