### PR TITLE
Update Reactiflux information for Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Feel free to open an issue on our [**discussion forum**](https://github.com/refl
 
 1. The [discussion forum](https://github.com/reflux/discuss)
 2. [StackOverflow with the `refluxjs` tag](http://stackoverflow.com/questions/tagged/refluxjs)
-3. [`#reflux` channel](https://reactiflux.slack.com/messages/reflux/) on Reactiflux Slack group. [Sign up here](http://reactiflux.com/) for an account.
+3. `#reflux` channel on Reactiflux Discord group. [Sign up here](http://join.reactiflux.com/) for an account.
 4. [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/spoike/refluxjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 5. [![Thinkful][thinkful-image]][thinkful-url]
 


### PR DESCRIPTION
Reactiflux is no longer on Slack, so the first link took users to the deprecated (but not deleted) Slack group full of leftsharks, and the second link doesn't point to the newest signup form.